### PR TITLE
60 hide enemy moves

### DIFF
--- a/dunwoody_disaster/FightSequence.py
+++ b/dunwoody_disaster/FightSequence.py
@@ -15,6 +15,7 @@ class FightSequence:
         self.player = player
         self.enemy = enemy
         self.widget = FightScreen(self)
+        self._locked = False
 
         self._winCallback = DD.unimplemented
         self._loseCallback = DD.unimplemented
@@ -23,6 +24,10 @@ class FightSequence:
         """
         Show enemy actions, then pause.
         """
+        if self._locked:
+            return
+
+        self._locked = True
         enemyActions.show()
         callback = partial(self.finishTurn, playerActions, enemyActions)
         QTimer.singleShot(1000, callback)
@@ -62,6 +67,9 @@ class FightSequence:
             self._winCallback()
         elif self.player.curHealth <= 0:
             self._loseCallback()
+
+        self._locked = False
+        return
 
     def calculateDamage(
         self, player: Character, attack: Item.Weapon, defense: Item.Armor

--- a/dunwoody_disaster/FightSequence.py
+++ b/dunwoody_disaster/FightSequence.py
@@ -4,6 +4,8 @@ from dunwoody_disaster.views.action_selector import ActionSelector
 from dunwoody_disaster.views.fightScreen import FightScreen
 from typing import Callable
 import dunwoody_disaster as DD
+from PySide6.QtCore import QTimer
+from functools import partial
 
 
 class FightSequence:
@@ -19,10 +21,20 @@ class FightSequence:
 
     def takeTurn(self, playerActions: ActionSelector, enemyActions: ActionSelector):
         """
+        Show enemy actions, then pause.
+        """
+        enemyActions.show()
+        callback = partial(self.finishTurn, playerActions, enemyActions)
+        QTimer.singleShot(1000, callback)
+
+    def finishTurn(self, playerActions: ActionSelector, enemyActions: ActionSelector):
+        """
         Update the characters after using a move
         :param playerActions: The actions the player is using
         :param enemyActions: The actions the enemy is using
         """
+        enemyActions.hide()
+
         playerDmg = self.calculateDamage(
             self.player, enemyActions.getAttack(), playerActions.getDefense()
         )

--- a/dunwoody_disaster/views/action_selector.py
+++ b/dunwoody_disaster/views/action_selector.py
@@ -10,6 +10,7 @@ import random
 class ActionSelector(QWidget):
     def __init__(self, character: Character):
         super().__init__()
+        self._hidden = False
         self.character = character
         self.attack: Optional[Item.Weapon] = None
         self.defense: Optional[Item.Armor] = None
@@ -65,14 +66,27 @@ class ActionSelector(QWidget):
         return self.defense
 
     def updateUI(self):
+        attack = ""
         if self.attack:
-            self.attack_pic.setPixmap(QPixmap(self.attack.image).scaledToWidth(50))
+            attack = self.attack.image
+            if self._hidden:
+                attack = DD.ASSETS["no_texture"]
+
+        defense = ""
+        if self.defense:
+            defense = self.defense.image
+            if self._hidden:
+                defense = DD.ASSETS["no_texture"]
+
+        if attack:
+            self.attack_pic.setPixmap(QPixmap(attack).scaledToWidth(50))
         else:
             self.attack_pic.setPixmap(QPixmap())
-        if self.defense:
-            self.defend_pic.setPixmap(QPixmap(self.defense.image).scaledToWidth(50))
+        if defense:
+            self.defend_pic.setPixmap(QPixmap(defense).scaledToWidth(50))
         else:
             self.defend_pic.setPixmap(QPixmap())
+        return
 
     def ready(self) -> bool:
         return (self.attack and self.defense) is not None
@@ -113,3 +127,11 @@ class ActionSelector(QWidget):
         layout.addWidget(self.defend_pic)
         layout.addItem(DD.expander(True, False, 0))
         return layout
+
+    def hide(self):
+        self._hidden = True
+        self.updateUI()
+
+    def show(self):
+        self._hidden = False
+        self.updateUI()

--- a/dunwoody_disaster/views/action_selector.py
+++ b/dunwoody_disaster/views/action_selector.py
@@ -66,26 +66,22 @@ class ActionSelector(QWidget):
         return self.defense
 
     def updateUI(self):
-        attack = ""
         if self.attack:
             attack = self.attack.image
             if self._hidden:
                 attack = DD.ASSETS["no_texture"]
+            self.attack_pic.setPixmap(QPixmap(attack).scaledToWidth(50))
+        else:
+            self.attack_pic.setPixmap(QPixmap())
 
-        defense = ""
         if self.defense:
             defense = self.defense.image
             if self._hidden:
                 defense = DD.ASSETS["no_texture"]
-
-        if attack:
-            self.attack_pic.setPixmap(QPixmap(attack).scaledToWidth(50))
-        else:
-            self.attack_pic.setPixmap(QPixmap())
-        if defense:
             self.defend_pic.setPixmap(QPixmap(defense).scaledToWidth(50))
         else:
             self.defend_pic.setPixmap(QPixmap())
+
         return
 
     def ready(self) -> bool:

--- a/dunwoody_disaster/views/fightScreen.py
+++ b/dunwoody_disaster/views/fightScreen.py
@@ -27,6 +27,7 @@ class FightScreen(QWidget):
 
         self.p1_selector = ActionSelector(self.player1)
         self.p2_selector = ActionSelector(self.player2)
+        self.p2_selector.hide()
         self.p2_selector.selectRandom()
 
         self._winCallback = DD.unimplemented


### PR DESCRIPTION
The enemy moves are hidden until the user clicks `fight`, at which point they are shown for 1 second before being hidden again.